### PR TITLE
Detect malformed spreadsheet content

### DIFF
--- a/src/server/getBrexitLocals.js
+++ b/src/server/getBrexitLocals.js
@@ -33,7 +33,10 @@ export async function fetchBerthaData() {
 
 	const data = { links };
 
-	for (const { name, value } of options) data[name] = value;
+	for (const { name, value } of options) {
+		if(!name) throw new Error(`Malformed content. Make sure each name is defined in the name-value pairs: ${url}`);
+		data[name] = value;
+	}
 
 	// process text from markdown to html, then insert data-trackable attributes into any links
 	data.text = (() => {

--- a/src/server/getBrexitLocals.js
+++ b/src/server/getBrexitLocals.js
@@ -34,7 +34,7 @@ export async function fetchBerthaData() {
 	const data = { links };
 
 	for (const { name, value } of options) {
-		if(!name) throw new Error(`Malformed content. Found an undefined option label in the spreadsheet: ${url}`);
+		if(!name) throw new Error(`Malformed content. Found an undefined option name in the spreadsheet: ${url}`);
 		data[name] = value;
 	}
 

--- a/src/server/getBrexitLocals.js
+++ b/src/server/getBrexitLocals.js
@@ -34,7 +34,7 @@ export async function fetchBerthaData() {
 	const data = { links };
 
 	for (const { name, value } of options) {
-		if(!name) throw new Error(`Malformed content. Make sure each name is defined in the name-value pairs: ${url}`);
+		if(!name) throw new Error(`Malformed content. Found an undefined option label in the spreadsheet: ${url}`);
 		data[name] = value;
 	}
 

--- a/src/server/getUSElectionLocals.js
+++ b/src/server/getUSElectionLocals.js
@@ -14,7 +14,7 @@ export default async function getUSElectionLocals() {
 
 	const { options } = await contentRes.json();
 	for (const { name, value } of options) {
-		if(!name) throw new Error(`Malformed content. Found an undefined option label in the spreadsheet: ${contentURL}`);
+		if(!name) throw new Error(`Malformed content. Found an undefined option name in the spreadsheet: ${contentURL}`);
 		data[name] = value;
 	}
 
@@ -23,7 +23,7 @@ export default async function getUSElectionLocals() {
 	// build a convenient options lookup
 	const resultsOptions = {};
 	for (const { name, value } of allResultsSheets.options) {
-		if(!name) throw new Error(`Malformed content. Found an undefined option label in the spreadsheet: ${resultsURL}`);
+		if(!name) throw new Error(`Malformed content. Found an undefined option name in the spreadsheet: ${resultsURL}`);
 		resultsOptions[name] = value;
 	}
 

--- a/src/server/getUSElectionLocals.js
+++ b/src/server/getUSElectionLocals.js
@@ -13,13 +13,19 @@ export default async function getUSElectionLocals() {
 	const data = {};
 
 	const { options } = await contentRes.json();
-	for (const { name, value } of options) data[name] = value;
+	for (const { name, value } of options) {
+		if(!name) throw new Error(`Malformed content. Found an undefined option label in the spreadsheet: ${contentURL}`);
+		data[name] = value;
+	}
 
 	const allResultsSheets = await resultsRes.json();
 
 	// build a convenient options lookup
 	const resultsOptions = {};
-	for (const { name, value } of allResultsSheets.options) resultsOptions[name] = value;
+	for (const { name, value } of allResultsSheets.options) {
+		if(!name) throw new Error(`Malformed content. Found an undefined option label in the spreadsheet: ${resultsURL}`);
+		resultsOptions[name] = value;
+	}
 
 	// sort results by total delegates descending
 	let results = allResultsSheets.results;


### PR DESCRIPTION
Throws an error if any of the `name` column is undefined for a value in the spreadsheet, so the custom fragment transform in next-stream-page will use the last available good content
