### PR TITLE
Fix styles bleeding into next stream page

### DIFF
--- a/src/client/us-election-2016/card.scss
+++ b/src/client/us-election-2016/card.scss
@@ -1,27 +1,21 @@
 @import 'o-grid/main';
-@import 'o-fonts/main';
 @import 'o-colors/main';
-
-@include oFontsInclude(FinancierDisplayWeb);
-@include oFontsInclude(FinancierDisplayWeb, $weight: bold);
-@include oFontsInclude(FinancierTextWeb);
-@include oFontsInclude(MetricWeb);
 
 $button-color: #F7F7F7;
 $button-color-darker: oColorsGetPaletteColor('blue-2');
 $button-color-darker-still: darken($button-color-darker, 3%);
 $button-top-border-color: rgba(206,198,185,0.5);
 
-h2 {
-	font: normal 16px/1.375 oFontsGetFontFamilyWithFallbacks(MetricWeb);
-	margin-top: 0;
-	margin-bottom: 5px;
-}
-
 .ig-us-election-2016 {
 	margin: 0 0 35px;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+
+	h2 {
+		font: normal 16px/1.375 oFontsGetFontFamilyWithFallbacks(MetricWeb);
+		margin-top: 0;
+		margin-bottom: 5px;
+	}
 
 	&__container {
 		padding-bottom: 20px;

--- a/src/client/us-election-2016/iframe.scss
+++ b/src/client/us-election-2016/iframe.scss
@@ -5,6 +5,11 @@ $o-grid-layouts: (
 	XL: 1220px,
 );
 
+@import 'o-fonts/main';
+@include oFontsInclude(FinancierDisplayWeb);
+@include oFontsInclude(FinancierDisplayWeb, $weight: bold);
+@include oFontsInclude(MetricWeb);
+@import 'next-sass-setup/main';
 @import 'card';
 @import 'summary';
 

--- a/src/client/us-election-2016/summary.scss
+++ b/src/client/us-election-2016/summary.scss
@@ -1,5 +1,5 @@
 @import 'o-grid/main';
-@import 'next-sass-setup/main';
+@import 'o-colors/main';
 
 $button-color-darker: oColorsGetPaletteColor('blue-2');
 $button-color-darker-still: darken($button-color-darker, 3%);
@@ -35,7 +35,7 @@ $button-color-darker-still: darken($button-color-darker, 3%);
 
 	&__summary-text > p,
 	&__summary-secondary-text > p {
-		font: normal 18px/1.375 oFontsGetFontFamilyWithFallbacks(FinancierTextWeb);
+		font: normal 16px/1.375 Georgia, serif;
 		margin: 0 0 1em;
 	}
 


### PR DESCRIPTION
This moves font-face declarations and styles that seem to be needed
only for the Falcon iframe into the right place.

I’ve also removed the dependency on FinancierTextWeb as that’s not used
for body copy, it’s Georgia instead.
